### PR TITLE
Textarea size increased

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -379,7 +379,7 @@ class JellySnippetsSettingTab extends PluginSettingTab {
 			.setDesc(
 				"Specify your snippets here! Format: 'before<divider>after'. Surrounding your divider with a space is recommended for readability."
 			)
-			.addTextArea((textarea) =>
+			.addTextArea((textarea) => {
 				textarea
 					.setPlaceholder(
 						`before${this.plugin.settings.snippetPartDivider}after`
@@ -390,6 +390,10 @@ class JellySnippetsSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 						this.plugin.reloadSnippets(); // ? is this necessary to update the snippets?
 					})
+				// the following two lines make editing the snippets easier
+				textarea.inputEl.setAttr("rows", 6); 
+				textarea.inputEl.setAttr("cols", 40);
+			}
 			);
 
 		new Setting(childEl)


### PR DESCRIPTION
I added two lines of code so the textarea where you put your snippets is bigger.

![size](https://github.com/rabirabirara/obsidian-jelly-snippets/assets/68042106/c869c787-edb6-4797-a6c3-88b0bdfd9478)
